### PR TITLE
Fix BlogLandingHeader component typo

### DIFF
--- a/web/src/components/blog-landing-header.tsx
+++ b/web/src/components/blog-landing-header.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-export default function BlogLandigHeader() {
+export default function BlogLandingHeader() {
     return (
         <h2 className="text-slate-900 font-bold font-FigTree text-4xl sm:text-5xl lg:text-6xl tracking-normal text-center dark:text-white">
             My Thoughts


### PR DESCRIPTION
## Summary
- rename BlogLandigHeader to BlogLandingHeader

## Testing
- `npm test -- --watchAll=false` *(fails: Test Suites: 5 failed, 1 passed)*
- `cargo test` *(fails to compile)*

------
https://chatgpt.com/codex/tasks/task_e_683f38167dc88325b0731c3db462dc95