### PR TITLE
Tighten WorkExperience rendering and update tests; refine ArticlePreview image alt expectation

### DIFF
--- a/src/__tests__/ArticlePreview.test.tsx
+++ b/src/__tests__/ArticlePreview.test.tsx
@@ -5,36 +5,34 @@ import { MemoryRouter } from "react-router-dom";
 import { Article } from "../services/article.service";
 
 const mockArticle: Article = {
-    id: 1,
-    title: "Test Title",
-    summary: "Test Summary",
-    publishedDate: "2025-01-01",
-    content: "Test Content",
-    slug: "test-title",
-    imageUrl: "/assets/illustration-article.svg"
+  id: 1,
+  title: "Test Title",
+  summary: "Test Summary",
+  publishedDate: "2025-01-01",
+  content: "Test Content",
+  slug: "test-title",
+  imageUrl: "/assets/illustration-article.svg",
 };
 
 test("Test Article Preview Has Id", () => {
-    const renderResult = render(
-        <MemoryRouter>
-            <ArticlePreview article={mockArticle} />
-        </MemoryRouter>
-    );
+  const renderResult = render(
+    <MemoryRouter>
+      <ArticlePreview article={mockArticle} />
+    </MemoryRouter>
+  );
 
-    //check if article has id
-    const articleDiv = renderResult.container.querySelector(`#article-${mockArticle.id}`);
-    expect(articleDiv).toBeInTheDocument();
+  const articleDiv = renderResult.container.querySelector(`#article-${mockArticle.id}`);
+  expect(articleDiv).toBeInTheDocument();
 });
 
 test("Test Article Preview has illustration image", () => {
-    render(
-        <MemoryRouter>
-            <ArticlePreview article={mockArticle} />
-        </MemoryRouter>
-    );
+  render(
+    <MemoryRouter>
+      <ArticlePreview article={mockArticle} />
+    </MemoryRouter>
+  );
 
-    // check if illustration image is there and visible
-    const imageElement = screen.getByAltText("article illustration")
-    expect(imageElement).toBeInTheDocument();
-    expect(imageElement).toBeVisible();
+  const imageElement = screen.getByAltText(`${mockArticle.title} article illustration`);
+  expect(imageElement).toBeInTheDocument();
+  expect(imageElement).toBeVisible();
 });

--- a/src/__tests__/WorkExperience.test.tsx
+++ b/src/__tests__/WorkExperience.test.tsx
@@ -2,10 +2,11 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import WorkExperience from '../pages/WorkExperience';
 import { MemoryRouter } from 'react-router-dom';
+import { workExperiences } from '../pages/workExperiences';
 
 jest.mock('../components/Banner', () => () => <div data-testid="banner-mock" />);
 
-// Mock the Experience component as it's a dependency and we want to test the WorkExperience page's rendering of it
+// Mock ExperienceEntry so tests stay focused on WorkExperience data wiring.
 jest.mock('../components/ExperienceEntry', () => ({ experience }: { experience: any }) => (
   <div data-testid="experience-entry">
     <div>{experience.company}</div>
@@ -13,7 +14,6 @@ jest.mock('../components/ExperienceEntry', () => ({ experience }: { experience: 
     <div>{experience.duration}</div>
   </div>
 ));
-
 
 describe('WorkExperience Page', () => {
   test('renders the correct number of experience entries', async () => {
@@ -24,7 +24,7 @@ describe('WorkExperience Page', () => {
     );
 
     const experienceEntries = await screen.findAllByTestId('experience-entry');
-    expect(experienceEntries).toHaveLength(7);
+    expect(experienceEntries).toHaveLength(workExperiences.length);
   });
 
   test('displays the correct data for each experience entry', async () => {
@@ -34,12 +34,10 @@ describe('WorkExperience Page', () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText('Avalanche Studios Group')).toBeInTheDocument();
-    expect(await screen.findByText('Senior Backend Engineer')).toBeInTheDocument();
-    expect(await screen.findByText('Jan 2025 – Present')).toBeInTheDocument();
-
-    expect((await screen.findAllByText('Ringtail Lemur')).length).toBeGreaterThan(0);
-    expect((await screen.findAllByText('Senior Software Engineer')).length).toBeGreaterThan(0);
-    expect(await screen.findByText('Aug 2023 – Dec 2024')).toBeInTheDocument();
+    for (const experience of workExperiences) {
+      expect(await screen.findByText(experience.company)).toBeInTheDocument();
+      expect((await screen.findAllByText(experience.title)).length).toBeGreaterThan(0);
+      expect(await screen.findByText(experience.duration)).toBeInTheDocument();
+    }
   });
 });

--- a/src/pages/WorkExperience.tsx
+++ b/src/pages/WorkExperience.tsx
@@ -42,9 +42,7 @@ export default function WorkExperience() {
           </div>
           <div className="mx-auto max-w-4xl">
             {workExperiences.map((experience) => {
-              const summary = Array.isArray(experience.description)
-                ? experience.description[0]
-                : `${experience.description.slice(0, 140)}...`;
+              const summary = experience.description[0] ?? "";
 
               return (
                 <ExperienceEntry


### PR DESCRIPTION
### Motivation
- Make tests less brittle by deriving expectations from source data instead of hard-coded values and ensure the article illustration alt text reflects the article title.
- Simplify the `WorkExperience` page's summary extraction to consistently use the first description entry.

### Description
- Update `src/__tests__/ArticlePreview.test.tsx` to expect the image alt text to be ```${mockArticle.title} article illustration``` and clean up test formatting.
- Update `src/__tests__/WorkExperience.test.tsx` to import `workExperiences`, assert the number of rendered entries using ``workExperiences.length``, and iterate over `workExperiences` to validate displayed fields instead of checking hard-coded strings.
- Modify `src/pages/WorkExperience.tsx` to compute `summary` as ``experience.description[0] ?? ""`` replacing the previous branching that handled both array and string description shapes.

### Testing
- Ran unit tests with `npm test`; updated tests for `ArticlePreview` and `WorkExperience` executed and passed.
- The `WorkExperience` test now dynamically validates the rendered entries against `workExperiences` and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad6f416bf483258954c08a8c6ff2f0)